### PR TITLE
Adds option to specify filetype other than "markdown"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# ncm2-markdown-subscope
+
+Language-specific completion for markdown fenced code blocks.
+
+## Config
+
+Completion will be enabled for the languages specified in
+
+```
+g:markdown_fenced_languages
+```
+
+if using tpope's [vim-markdown](https://github.com/tpope/vim-markdown) plugin,
+or
+
+```
+g:vim_markdown_fenced_languages
+```
+
+if using plasticboy's
+[vim-markdown](https://github.com/plasticboy/vim-markdown).
+
+### `g:ncm2_markdown_subscope#filetypes`
+
+Defaults to `['markdown']`.
+
+A list of filetypes that the plugin should work for. This is useful if you have
+files that have an e.g. `vimwiki.markdown` filetype.

--- a/pythonx/ncm2_subscope_detector/markdown.py
+++ b/pythonx/ncm2_subscope_detector/markdown.py
@@ -27,7 +27,7 @@ for element in vim.eval('get(g:, "markdown_fenced_languages", []) \
 
 class SubscopeDetector(Ncm2Base):
 
-    scope = ['markdown']
+    scope = vim.vars.get("ncm2_markdown_subscope#filetypes", ["markdown"])
 
     def detect(self, lnum, ccol, src):
 


### PR DESCRIPTION
I want the plugin to also work for `vimwiki.markdown`.